### PR TITLE
Updated Travis CI Golang testing versions for 2020.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,13 @@
 language: go
 
 go:
+  # n.b. For golang release history, see https://golang.org/doc/devel/release.html
   - tip
-  - "1.10"
-  - 1.9
-  - 1.8
-  - 1.7
-  - 1.6
-  - 1.5
-  - 1.4
+  - "1.13.8"
+  - "1.12.17"
+  - "1.11.13"
+  - "1.10.8"
+  - "1.9.7"
 
 notifications:
   email:

--- a/cancellable_retry.go
+++ b/cancellable_retry.go
@@ -5,9 +5,9 @@ import (
 	"sync"
 	"time"
 
-	log "github.com/Sirupsen/logrus"
 	"github.com/cenkalti/backoff"
 	"github.com/gigawattio/errorlib"
+	log "github.com/sirupsen/logrus"
 )
 
 type Action struct {

--- a/retry_until_success.go
+++ b/retry_until_success.go
@@ -3,8 +3,8 @@ package gentle
 import (
 	"time"
 
-	log "github.com/Sirupsen/logrus"
 	"github.com/cenkalti/backoff"
+	log "github.com/sirupsen/logrus"
 )
 
 // retryUntilSuccess will keep attempting an operation until it succeeds.


### PR DESCRIPTION
- Added Go versions 1.9.7, 1.10.8, 1.11.13, 1.12.17, and 1.13.8.
- Dropped Go versions 1.4, 1.5, 1.6, 1.7, 1.8, 1.9, and 1.10.